### PR TITLE
no-unused-vars to warn

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,10 @@ export = {
     'typescript/no-angle-bracket-type-assertion': 'error',
     'typescript/no-namespace': 'error',
     'typescript/no-use-before-define': ['error', { functions: false, classes: false, variables: false, typedefs: false }],
-    'typescript/no-unused-vars': 'error',
+
+    'no-unused-vars': 'warn', // https://github.com/nzakas/eslint-plugin-typescript/pull/84
+    'typescript/no-unused-vars': 'warn',
+
     'typescript/adjacent-overload-signatures': 'error',
     'typescript/member-delimiter-style': ['error', { delimiter: 'none' }],
     'typescript/no-empty-interface': 'error'


### PR DESCRIPTION
Because of https://github.com/nzakas/eslint-plugin-typescript/pull/84.