### PR TITLE
chore: update to the new `@typescript-eslint`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,7 @@
 {
   "extends": "./lib/index.js",
-  "parser": "typescript-eslint-parser"
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": "./tsconfig.json"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,47 @@
       "integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA==",
       "dev": true
     },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.4.2.tgz",
+      "integrity": "sha512-6WInypy/cK4rM1dirKbD5p7iFW28DbSRKT/+PGn+DYzBWEvHq5KnZAqQ5cX25JBc0qMkFxJNxNfBbFXJyyzVcw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/parser": "1.4.2",
+        "@typescript-eslint/typescript-estree": "1.4.2",
+        "requireindex": "^1.2.0",
+        "tsutils": "^3.7.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.4.2.tgz",
+      "integrity": "sha512-OqLkY9295DXXaWToItUv3olO2//rmzh6Th6Sc7YjFFEpEuennsm5zhygLLvHZjPxPlzrQgE8UDaOPurDylaUuw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/typescript-estree": "1.4.2",
+        "eslint-scope": "^4.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.4.2.tgz",
+      "integrity": "sha512-wKgi/w6k1v3R4b6oDc20cRWro2gBzp0wn6CAeYC8ExJMfvXMfiaXzw2tT9ilxdONaVWMCk7B9fMdjos7bF/CWw==",
+      "dev": true,
+      "requires": {
+        "lodash.unescape": "4.0.1",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
+        }
+      }
+    },
     "acorn": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
@@ -487,15 +528,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz",
       "integrity": "sha512-OwxJkR6TQiYMmt1EsNRMe5qG3GsbjlcOhbGUBY4LtavF9DsLaTcoR+j2Tdjqi23oUwKNUqX7qcn5fPStafMdlA==",
       "dev": true
-    },
-    "eslint-plugin-typescript": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-typescript/-/eslint-plugin-typescript-0.13.0.tgz",
-      "integrity": "sha512-dN8EwZfkOobYJ6VCFJ0Kd39OLSectdJlkG5L+VmA2BtMunZALQus6XLx21Gkj6vmfmUDk6uEGCB7JCszhvZoTA==",
-      "dev": true,
-      "requires": {
-        "requireindex": "~1.1.0"
-      }
     },
     "eslint-scope": {
       "version": "4.0.0",
@@ -1316,9 +1348,9 @@
       }
     },
     "requireindex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
-      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
       "dev": true
     },
     "resolve": {
@@ -1563,6 +1595,15 @@
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
       "dev": true
     },
+    "tsutils": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.8.0.tgz",
+      "integrity": "sha512-XQdPhgcoTbCD8baXC38PQ0vpTZ8T3YrE+vR66YIj/xvDt1//8iAhafpIT/4DmvzzC1QFapEImERu48Pa01dIUA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -1577,35 +1618,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
       "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
       "dev": true
-    },
-    "typescript-eslint-parser": {
-      "version": "21.0.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-21.0.2.tgz",
-      "integrity": "sha512-u+pj4RVJBr4eTzj0n5npoXD/oRthvfUCjSKndhNI714MG0mQq2DJw5WP7qmonRNIFgmZuvdDOH3BHm9iOjIAfg==",
-      "dev": true,
-      "requires": {
-        "eslint-scope": "^4.0.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "typescript-estree": "5.3.0"
-      }
-    },
-    "typescript-estree": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/typescript-estree/-/typescript-estree-5.3.0.tgz",
-      "integrity": "sha512-Vu0KmYdSCkpae+J48wsFC1ti19Hq3Wi/lODUaE+uesc3gzqhWbZ5itWbsjylLVbjNW4K41RqDzSfnaYNbmEiMQ==",
-      "dev": true,
-      "requires": {
-        "lodash.unescape": "4.0.1",
-        "semver": "5.5.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-          "dev": true
-        }
-      }
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -54,20 +54,21 @@
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "eslint-plugin-typescript": "^0.13.0"
+    "@typescript-eslint/eslint-plugin": "^1.4.2",
+    "@typescript-eslint/parser": "^1.4.2"
   },
   "devDependencies": {
     "@types/node": "^10.12.10",
+    "@typescript-eslint/eslint-plugin": "^1.4.2",
+    "@typescript-eslint/parser": "^1.4.2",
     "eslint": "^5.8.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "eslint-plugin-typescript": "^0.13.0",
     "npm-run-all": "^4.1.3",
     "tsconfigs": "^3.0.0",
     "tslib": "^1.9.3",
-    "typescript": "^3.1.6",
-    "typescript-eslint-parser": "^21.0.0"
+    "typescript": "^3.1.6"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -5,12 +5,12 @@
 
 # eslint-config-standard-with-typescript
 
-An [ESLint shareable config](https://eslint.org/docs/developer-guide/shareable-configs) for TypeScript that is based on [eslint-config-standard](https://github.com/standard/eslint-config-standard) and has TypeScript specific rules from [eslint-plugin-typescript](https://github.com/nzakas/eslint-plugin-typescript).
+An [ESLint shareable config](https://eslint.org/docs/developer-guide/shareable-configs) for TypeScript that is based on [eslint-config-standard](https://github.com/standard/eslint-config-standard) and has TypeScript specific rules from [@typescript-eslint/eslint-plugin](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin).
 
 ## Usage
 
 ```
-npm install --save-dev eslint-plugin-standard eslint-plugin-promise eslint-plugin-import eslint-plugin-node typescript-eslint-parser eslint-plugin-typescript eslint-config-standard-with-typescript 
+npm install --save-dev eslint-plugin-standard eslint-plugin-promise eslint-plugin-import eslint-plugin-node @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-config-standard-with-typescript 
 ```
 
 Yes, I know it is a large number of packages. This is due to [a known design flaw in ESLint](https://github.com/eslint/eslint/issues/10125).
@@ -18,17 +18,22 @@ Yes, I know it is a large number of packages. This is due to [a known design fla
 This long list of dependencies includes:
 
 1. Peer dependencies of [eslint-config-standard](https://github.com/standard/eslint-config-standard)
-1. the necessary [typescript-eslint-parser](https://github.com/eslint/typescript-eslint-parser/); lets ESLint parse TypeScript.
-1. [eslint-plugin-typescript](https://github.com/nzakas/eslint-plugin-typescript); ESLint rules for TypeScript.
+1. the necessary [@typescript-eslint/parser](https://www.npmjs.com/package/@typescript-eslint/parser); lets ESLint parse TypeScript.
+1. [@typescript-eslint/eslint-plugin](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin); ESLint rules for TypeScript.
 
 Here is an example `.eslintrc.json`:
 
 ```json
 {
   "extends": "standard-with-typescript",
-  "parser": "typescript-eslint-parser"
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+      "project": "./tsconfig.json"
+  },
 }
 ```
+
+There are [some more `parserOptions`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/parser/README.md#configuration) you might care about.
 
 Make sure you read about [the `--ext` command line option](https://eslint.org/docs/user-guide/command-line-interface#--ext). And here is [a feature request for specifying extensions in the config](https://github.com/eslint/eslint/issues/10828).
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,35 +1,64 @@
 export = {
   extends: 'eslint-config-standard',
-  parserOptions: {
-    ecmaFeatures: {
-      // https://github.com/standard/eslint-config-standard/issues/95
-      jsx: false
-    }
-  },
-  plugins: ['typescript'],
+  plugins: ['@typescript-eslint'],
   overrides: [
     {
       files: ['*.ts'],
       rules: {
-        'camelcase': ['warn', { properties: 'never' }], // https://github.com/mightyiam/eslint-config-standard-with-typescript/issues/3
-        'no-array-constructor': 'off', // in favor of TypeScript rule
+        'camelcase': 'off', // in favor of TypeScript rule
+        'indent': 'off',
+        'no-array-constructor': 'off',
         'no-undef': 'off', // TypeScript has this functionality by default
-        'no-unused-vars': 'off', // TypeScript has `noUnusedLocals` and `noUnusedParameters`
-        'no-useless-constructor': 'warn', // https://github.com/mightyiam/eslint-config-standard-with-typescript/issues/2
-        'typescript/adjacent-overload-signatures': 'error',
-        'typescript/explicit-function-return-type': 'error',
-        'typescript/explicit-member-accessibility': 'error',
-        'typescript/member-delimiter-style': ['error', { delimiter: 'none' }],
-        'typescript/no-angle-bracket-type-assertion': 'error',
-        'typescript/no-array-constructor': 'error',
-        'typescript/no-empty-interface': 'error',
-        'typescript/no-namespace': 'error',
-        'typescript/no-non-null-assertion': 'error',
-        'typescript/no-triple-slash-reference': 'error',
-        'typescript/no-unused-vars': 'error',
-        'typescript/no-use-before-define': ['error', { functions: false, classes: false, variables: false, typedefs: false }],
-        'typescript/no-var-requires': 'error',
-        'typescript/type-annotation-spacing': 'error'
+        'no-unused-vars': 'off', // in favor of TypeScript rule
+        'no-useless-constructor': 'off',
+        '@typescript-eslint/adjacent-overload-signatures': 'error',
+        '@typescript-eslint/array-type': ['error', 'array-simple'],
+        '@typescript-eslint/camelcase': ['error', { properties: 'never' }],
+        '@typescript-eslint/explicit-function-return-type': 'error',
+        '@typescript-eslint/explicit-member-accessibility': 'error',
+        '@typescript-eslint/indent': ['error', 2, {
+          'SwitchCase': 1,
+          'VariableDeclarator': 1,
+          'outerIIFEBody': 1,
+          'MemberExpression': 1,
+          'FunctionDeclaration': { 'parameters': 1, 'body': 1 },
+          'FunctionExpression': { 'parameters': 1, 'body': 1 },
+          'CallExpression': { 'arguments': 1 },
+          'ArrayExpression': 1,
+          'ObjectExpression': 1,
+          'ImportDeclaration': 1,
+          'flatTernaryExpressions': false,
+          'ignoreComments': false
+        }],
+        '@typescript-eslint/member-delimiter-style': [
+          'error',
+          {
+            multiline: { delimiter: 'none' },
+            singleline: { delimiter: 'comma', requireLast: false }
+          }
+        ],
+        '@typescript-eslint/no-angle-bracket-type-assertion': 'error',
+        '@typescript-eslint/no-array-constructor': 'error',
+        '@typescript-eslint/no-empty-interface': 'error',
+        '@typescript-eslint/no-extraneous-class': 'error',
+        '@typescript-eslint/no-for-in-array': 'error',
+        '@typescript-eslint/no-misused-new': 'error',
+        '@typescript-eslint/no-namespace': 'error',
+        '@typescript-eslint/no-non-null-assertion': 'error',
+        '@typescript-eslint/no-object-literal-type-assertion': 'error',
+        '@typescript-eslint/no-this-alias': ['error', { allowDestructuring: true }],
+        '@typescript-eslint/no-triple-slash-reference': 'error',
+        '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+        '@typescript-eslint/no-unused-vars': 'error',
+        '@typescript-eslint/no-use-before-define': ['error', { functions: false, classes: false, variables: false, typedefs: false }],
+        '@typescript-eslint/no-useless-constructor': 'error',
+        '@typescript-eslint/no-var-requires': 'error',
+        '@typescript-eslint/prefer-function-type': 'error',
+        '@typescript-eslint/prefer-interface': 'error',
+        '@typescript-eslint/promise-function-async': 'error',
+        '@typescript-eslint/restrict-plus-operands': 'error',
+        '@typescript-eslint/require-array-sort-compare': 'error',
+        '@typescript-eslint/type-annotation-spacing': 'error'
       }
     }
   ]


### PR DESCRIPTION
BREAKING CHANGE: Users would have to:
- uninstall `typescript-eslint-parser eslint-plugin-typescript`
- install `@typescript-eslint/parser @typescript-eslint/eslint-plugin`
- determine whether their TypeScript version is compatible
- ESLint configuration:
  - change `parser` to `@typescript-eslint/parser`
  - add `parserOptions.project`
- tend to possible new linting errors from:
  - several new added rules
  - numerous fixed rules