### PR TITLE
Update eslint-plugin-node peerDependency to 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "peerDependencies": {
     "eslint": "^5.8.0",
     "eslint-plugin-import": "^2.14.0",
-    "eslint-plugin-node": "^8.0.0",
+    "eslint-plugin-node": "^9.0.0",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^1.4.2",


### PR DESCRIPTION
eslint-plugin-node is at 9.1.0

We should upgrade this peerDependency to ^9.0.0 or at least >=8.0.0