### PR TITLE
Apply rules to .tsx files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export = {
   plugins: ['@typescript-eslint'],
   overrides: [
     {
-      files: ['*.ts'],
+      files: ['*.ts', '*.tsx'],
       rules: {
         'camelcase': 'off', // in favor of TypeScript rule
         'indent': 'off',


### PR DESCRIPTION
I think this addresses the issue in https://github.com/mightyiam/eslint-config-standard-with-typescript/issues/66, but I'll go into more detail.

To use JSX in a TypeScript file, the compiler makes you give the file a `.tsx` extension. Besides for maybe including JSX, `.tsx` files are completely normal TypeScript files.

As a result of https://github.com/mightyiam/eslint-config-standard-with-typescript/pull/44, the rules in this config only apply to `.ts` files. This causes `.tsx` files to not be linted properly, with erroneous ESLint errors being reported, and typescript-eslint errors not being reported. I tested the change in this PR with one of my projects, and in that project alone, applying this config to `.tsx` files resolved 14 false positives and revealed 91 false negatives (I can provide my lint reports if you're interested).

This does not appear to create any new issues with `.tsx` files. This, alongside [eslint-config-standard-jsx](https://github.com/standard/eslint-config-standard-jsx), lints my `.tsx` files perfectly.